### PR TITLE
feat: Allow combining scoped and global scores

### DIFF
--- a/docs/02_The_Primitives.md
+++ b/docs/02_The_Primitives.md
@@ -4,11 +4,11 @@ You can think about Impact as two sets of primitives.
 
 ## 1. Management primitives
 
-It does not really matter what state primitives you use, it is the fact that these primitives can be encapsulated and interacted with in a predictable and organised manner that is the "management" of "state management".
+It does not really matter what state primitives you use, it is way these primitives can be encapsulated and interacted with that is the "management" of "state management".
 
 ### Store
 
-The store in Impact is a management primitive, not a state primitive. It can encapsulate state and related logic to manage that state, but this is not required to define a store. The store is just a function which returns a public interface that can be consumed by components and other stores using the hooks pattern. You will not define one big store, but rather define several smaller stores with specific responsibilities and public interfaces as you expect from the hooks pattern.
+The store in Impact is a management primitive, not a state primitive. It can encapsulate state and related logic to manage that state, but this is not required to define a store. The store is just a function which returns a public interface that can be consumed by components and other stores using the hooks pattern. You will not define one big store, but rather define several smaller stores with specific responsibilities and public interfaces.
 
 ### StoresProvider
 

--- a/docs/03_Understanding_The_Design.md
+++ b/docs/03_Understanding_The_Design.md
@@ -1,6 +1,6 @@
 # Understanding The Design
 
-Reacts responsibility is to compose dynamic user interfaces and doing so across the client and server boundary. The primitives of React for state and managing that state are scoped to individual components and you rely on mechanisms like props passing and context providers to share state and logic between components. A common misconception about React is that its primitives is designed to manage state, but they are really more about synchronising state. It quite quickly becomes cumbersome to use Reacts primitives to share state and state management across components in a way that performs and scales. Also expressing state management with the mental overhead of the reconciliation loop creates friction.
+Reacts responsibility is to compose dynamic user interfaces and doing so across the client and server boundary. The primitives of React for state are scoped to individual components and you rely on mechanisms like props passing and context providers to share state and management of that state between components. A common misconception about React is that its primitives is designed to manage state, but they are really more about synchronising state. It quite quickly becomes cumbersome to use Reacts primitives to share state and state management across components in a way that performs and scales. Also expressing state management with the mental overhead of the reconciliation loop creates friction.
 
 **The first principle** of **Impact** is to allow scoping state and management of the state to component trees, as opposed to using only a global scope.
 
@@ -16,7 +16,7 @@ Impact is not really about its state primitives, it is about how you organise an
 
 **So what is this fundamental "management building block"?**
 
-We are not being fancy about this, it is still called **stores**. A store is just a function encapsulating state and management of that state which can be exposed globally or scoped to a component tree. It is the same composition model you love from React hooks, but with primitives designed for reactivity. Most importantly these stores run outside the reconciliation loop of React, meaning you avoid the performance and mental overhead of using traditional hooks to share state and management of that state across components.
+We are not being fancy about this, it is still called **stores**. A store is just a function encapsulating state and management of that state which can be exposed globally or scoped to a component tree. It is the same composition model you love from React hooks, but with primitives designed for reactivity. Most importantly these stores run outside the reconciliation loop of React, meaning you avoid the performance and mental overhead of using traditional hooks.
 
 ## Concurrent mode
 

--- a/docs/05_API.md
+++ b/docs/05_API.md
@@ -32,7 +32,7 @@ function OtherStore () {
 }
 
 function MessageStore() {
-    // Use the hook in a store
+    // Use the "useStore" hook in a store to consume an other store
     const otherStore = useStore(OtherStore)
     
     return {
@@ -41,7 +41,7 @@ function MessageStore() {
 }
 
 function MessageComponent() {
-    // Or use it in a component
+    // Or use "useStore" in a component
     const messageStore = useStore(MessageStore)
 
     return <div>{messageStore.message}</div>
@@ -50,7 +50,7 @@ function MessageComponent() {
 
 ## createStoresProvider
 
-Creating a `StoresProvider` allows you to define what stores are shared by what components and other stores. Typically you create one provider at the root of your component tree to capture all stores resolvement and control which stores are considered global to the application and which are scoped to specific pages/features.
+Creating a `StoresProvider` allows you to define what stores are shared by what components and other stores.
 
 ```tsx
 import { createStoresProvider } from 'impact-app'

--- a/docs/06_Stores.md
+++ b/docs/06_Stores.md
@@ -2,7 +2,7 @@
 
 ## Creating a store
 
-A store is just a function that returns state and/or logic, just like any other traditional React hook. We call it a store because it runs outside of React and enables reactive behaviour by the usage of reactive state primitives within it, like the signals from **Impact**. That means on its own a store is not reactive, it is a just a container for reactive primitives.
+A store is just a function that returns state and/or management of that state, just like any other traditional React hook. We call it a store because it runs outside of React and enables reactive behaviour by the usage of reactive state primitives within it, like the signals from **Impact**. That means on its own a store is not reactive, it is a just a container for reactive primitives.
 
 ```ts
 export function SomeStore() { 
@@ -26,7 +26,7 @@ function SomeComponent() {
 }
 ```
 
-The `StoresProvider` allows you to scope your stores to a component tree. The components in the component tree consuming the stores from a `StoresProvider` will all consume the same instance of stores. When the `StoresProvider` unmounts any `useCleanup` callbacks will be called on the resolved stores.
+The `StoresProvider` allows you to scope your stores to a component tree. The components in the component tree consuming the stores from a `StoresProvider` will all consume the same instance of stores. When a store is being resolved in a `StoresProvider` and can not be found the resolvement will propagate up the component tree, all the way up to the global stores. When a `StoresProvider` unmounts any `useCleanup` callbacks will be called on the resolved stores.
 
 ```tsx
 import { createStoresProvider, useStore, useCleanup } from 'impact-app'
@@ -42,9 +42,6 @@ function SomeStore() {
 const StoresProvider = createStoresProvider({ SomeStore })
 
 function SomeComponent() {
-    /*
-        When the component has a parent "StoresProvider" it will throw an error if "SomeStore" can not be resolved. 
-    */
     const someStore = useStore(SomeStore)
 }
 
@@ -167,9 +164,9 @@ It can be a good idea to structure your application as a set of pages and/or fea
     index.tsx
 ```
 
-The `/global-stores` at the root represents stores across the entire project, which will be available to any component and other stores. Where `/features/project/stores` are stores available to the project feature and any components and other hooks within it.
+The `/global-stores` at the root represents stores across the entire project. These stores does not have to be exposed on a `StoresProvider`, but it can be a good idea to expose these on their own `StoresProvider` at the root level of your application. That way if any of the stores needs to initialize with some data, they can using the provider. The stores within `/features/project/stores` are stores available to the project feature and any stores, components and hooks within it.
 
-The `global-stores/index.tsx` file would be where you define the `StoresProvider`, here showing `features/project/stores/index.ts`
+The `features/project/stores/index.ts` could organise the stores like this:
 
 ```ts 
 import { createStoresProvider } from 'impact-app'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "impact-app",
-  "version": "0.30.1",
+  "version": "0.31.0",
   "description": "Composable Stores for React",
   "author": "Christian Alfoni <christianalfoni@gmail.com>",
   "license": "MIT",

--- a/src/StoresProvider.tsx
+++ b/src/StoresProvider.tsx
@@ -29,7 +29,6 @@ class StoresContainer {
   constructor(
     stores: Array<Store<any, any[]> | [Store<any, any[]>, () => any]>,
     private _parent: StoresContainer | null,
-    private _isGlobal: boolean = false,
   ) {
     stores.forEach((store) => {
       if (Array.isArray(store)) {
@@ -61,18 +60,11 @@ class StoresContainer {
 
     if (!existingStore) {
       // If we are at the global container, we register the store automatically
-      if (this._isGlobal) {
+      if (!this._parent) {
         // @ts-ignore
         this.register(store, () => store());
 
         return this.resolve(store);
-      }
-
-      // If we are at a root container we stop resolving and rather throw an error
-      if (!this._parent) {
-        throw new Error(
-          `The store "${store.name}" is not registered to a StoresProvider`,
-        );
       }
 
       // We resolve up the tree when we have a parent and no store registered
@@ -112,7 +104,7 @@ ${String(e)}`);
   }
 }
 
-export const globalStoresContainer = new StoresContainer([], null, true);
+export const globalStoresContainer = new StoresContainer([], null);
 
 const context = createContext<StoresContainer | null>(null);
 
@@ -141,7 +133,7 @@ export class StoresProvider<
         this.props.stores,
         // eslint-disable-next-line
         // @ts-ignore
-        this.context,
+        this.context || globalStoresContainer,
       );
     }
 


### PR DESCRIPTION
Even though resolving a store through a provider it now falls back to global stores. Later we could introduce a `root` property to a `StoresProvider` to get back forced registration of stores.