### PR TITLE
fix: Wrong inferred return type of signal

### DIFF
--- a/impact-app/package.json
+++ b/impact-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "impact-app",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "Reactive applications for React",
   "author": "Christian Alfoni <christianalfoni@gmail.com>",
   "license": "MIT",

--- a/impact-app/src/signal.ts
+++ b/impact-app/src/signal.ts
@@ -210,7 +210,7 @@ export function signal<T>(initialValue: T) {
         signal.notify();
       }
     },
-  };
+  } as Signal<T>;
 }
 
 type PendingPromise<T> = Promise<T> & {


### PR DESCRIPTION
Update package.json version to 0.48.1 and add type annotation to signal object