### PR TITLE
fix: Do not include Vite FS stuff in stack trace

### DIFF
--- a/impact-debugger/package.json
+++ b/impact-debugger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "impact-debugger",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Reactive applications for React",
   "author": "Christian Alfoni <christianalfoni@gmail.com>",
   "license": "MIT",

--- a/impact-debugger/src/index.ts
+++ b/impact-debugger/src/index.ts
@@ -99,7 +99,9 @@ function createStackFrameData(stack: string) {
           line.includes(window.location.origin) &&
           !line.includes("createSetterDebugEntry") &&
           !line.includes("createGetterDebugEntry") &&
-          !line.includes("impact-app"),
+          !line.includes("impact-app") &&
+          // Vite
+          !line.includes("@fs"),
       );
 
     const stackFrameData: Array<{


### PR DESCRIPTION
Update impact-debugger version to 0.2.6 and exclude lines with '@fs' from impact-debugger