### PR TITLE
fix: Docs update

### DIFF
--- a/docs/learn/closures.md
+++ b/docs/learn/closures.md
@@ -20,7 +20,7 @@ code: |
 
 # Closures
 
-Whenever you change state in a component React will call the component function again and reconcile. In the previous example code the component had only one active closure at any time, cause there is only one function... the component. Reconciliation is a fantastic feature of React. Because of this you can just use normal JavaScript syntax to create conditions, loops, switches etc. to describe your UI.
+Whenever you change state in a component React will call the component function again and reconcile. In the previous example code the component had only one active closure at any time. Reconciliation is a fantastic feature of React. Because of this you can just use normal JavaScript syntax to create conditions, loops, switches etc. to describe your UI.
 
 In this code example we have introduced another scope. The `increase` function will be re-created when the component reconciles, but the component will always reference the first instance because of `useCallback`. The great thing about this is that the reference to `increase` never changes and you can safely pass the function to a nested component and take avantage of `memo` where needed to avoid unnecessary reconciliation. The problem though is that the component now operates with two closures at any time. The reconciliation closure of the component, and the `useCallback` closure which is created on the first render of the component.
 

--- a/docs/learn/context.md
+++ b/docs/learn/context.md
@@ -46,7 +46,7 @@ code: |
 With a React context we can overcome both challenges we just experienced passing props. By providing a context we can consume state and related management in any nested component. This is great, but it will introduce a new set of challenges:
 
 1. When the context value change reference, all consumers of the context reconciles. That means React contexts is an "all or nothing" deal. Components consuming the context reconciles on any change in the context, not by the state they actually consume
-2. The provider component will reconcile unrelated to actual changes within the context, so we need to make sure that the value we expose on the context does not unnnecessarily change reference. We need to use both `useCallback` and `useMemo` to ensure that reconciliation from a parent prevents the exposed value to change reference, or all components consuming the context reconciles as well
+2. The provider component will reconcile unrelated to actual changes within the context, so we need to make sure that the value we expose on the context does not unnnecessarily change reference. We need to use both `useCallback` and `useMemo` to ensure that reconciliation prevents the exposed value to change reference unnecessarily, or all components consuming the context reconciles as well
 
 ::: info
 
@@ -58,4 +58,5 @@ Even though the new [React Compiler](https://react.dev/blog/2024/02/15/react-lab
  <Playground />
 </ClientOnly>
 
-All the challenges mentioned this far is the reason why we have global state stores like [Redux](https://redux.js.org/), [Mobx](https://mobx.js.org/README.html) and the likes. These are all great solutions, but let us explore how Impact solves these challenges and how it differs from the others.
+
+All the challenges mentioned this far is the reason why we have global state stores like [Redux](https://redux.js.org/), [Mobx](https://mobx.js.org/README.html) and the likes. Global state stores certainly solves these challenges, but comes with their own limitations. Let us explore how Impact solves these challenges without limiting you to a global scope.

--- a/docs/learn/scoping.md
+++ b/docs/learn/scoping.md
@@ -48,3 +48,9 @@ Additionally the store can now receive props from the provider to initialise its
 <ClientOnly>
  <Playground />
 </ClientOnly>
+
+::: tip
+
+Another aspect of scoping state management is related to typing. When you scope state management you can receive resolved asynchronous state as a prop. The consumers of scoped state management can safely consume resolved asynchronous state, instead of having to check if the state is there, is pending or has an error.
+
+:::


### PR DESCRIPTION
Fix typo in the closure.md file by correcting 'cause' to 'because' for better clarity. and introduce a new tip section in the scoping.md file to discuss typing aspect of scoped state management.